### PR TITLE
[enh] experimental mingw crosscompile support

### DIFF
--- a/src/dkg.c
+++ b/src/dkg.c
@@ -2,7 +2,11 @@
 #include <stdint.h>
 #include <string.h>
 #include <time.h> // time
+#ifdef __WIN32__
+#include <winsock2.h>
+#else
 #include <arpa/inet.h> //htons
+#endif
 #include "toprf.h"
 #include "utils.h"
 #include "dkg.h"

--- a/src/makefile
+++ b/src/makefile
@@ -22,15 +22,13 @@ else
 	CFLAGS+=-Wl,-z,defs -Wl,-z,relro -Wl,-z,noexecstack -Wl,-z,now -Wtrampolines \
 			  -fsanitize=signed-integer-overflow -fsanitize-undefined-trap-on-error
 			  #-fstrict-flex-arrays=3 -mbranch-protection=standard
-	SOEXT=so
+	SOEXT?=so
 	SOFLAGS=-Wl,-soname,liboprf.$(SOEXT).$(SOVER)
    ifeq ($(ARCH),x86_64)
 		CFLAGS+=-fcf-protection=full
    endif
 
-   ifeq ($(ARCH),parisc64)
-   else ifeq ($(ARCH),parisc64)
-   else
+   ifneq ($(ARCH),parisc64)
 		CFLAGS+=-fstack-clash-protection
    endif
 endif
@@ -47,6 +45,7 @@ CFLAGS+=$(INCLUDES)
 
 SOURCES=oprf.c toprf.c dkg.c dkg-vss.c utils.c tp-dkg.c mpmult.c stp-dkg.c $(EXTRA_SOURCES)
 OBJECTS=$(patsubst %.c,%.o,$(SOURCES))
+MAKETARGET=all
 
 all: liboprf.$(SOEXT) liboprf.$(STATICEXT) noise_xk/liboprf-noiseXK.$(SOEXT)
 
@@ -54,7 +53,7 @@ debug: DEFINES=-DTRACE
 debug: all
 
 asan:
-	CFLAGS=-fsanitize=address -static-libasan -g -march=native -Wall -O2 -g -fstack-protector-strong -fpic -Werror=format-security -Werror=implicit-function-declaration -Wl, -z,noexecstack
+	CFLAGS=-fsanitize=address -static-libasan -g -march=native -Wall -O2 -g -fstack-protector-strong -fpic -Werror=format-security -Werror=implicit-function-declaration -Wl,-z,noexecstack $(DEFINES)
 	ifeq ($(ARCH),x86_64)
 		CFLAGS+=-fcf-protection=full
 	endif
@@ -65,6 +64,15 @@ asan:
 	endif
 asan: LDFLAGS+= -fsanitize=address -static-libasan
 asan: all
+
+mingw64: CC=x86_64-w64-mingw32-gcc
+mingw64: LDFLAGS+=-L. -lws2_32 -Lwin/libsodium-win64/lib/ -Wl,-Bstatic -lsodium -Wl,-Bdynamic
+mingw64: CFLAGS=-march=native -Wall -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fpic -Werror=format-security -Werror=implicit-function-declaration -ftrapv $(DEFINES) $(INCLUDES) -Iwin/libsodium-win64/include/sodium -Iwin/libsodium-win64/include
+mingw64: SOEXT=dll
+mingw64: STATICEXT=dll
+mingw64: EXT=.exe
+mingw64: MAKETARGET=mingw64
+mingw64: win/libsodium-win64 noise_xk/liboprf-noiseXK.$(STATICEXT) liboprf.$(STATICEXT)
 
 AR ?= ar
 
@@ -78,10 +86,10 @@ liboprf.$(STATICEXT): $(OBJECTS)
 	$(AR) rcs $@ $^
 
 noise_xk/liboprf-noiseXK.$(SOEXT):
-	make -C noise_xk all
+	make -C noise_xk $(MAKETARGET)
 
 noise_xk/liboprf-noiseXK.$(STATICEXT):
-	make -C noise_xk all
+	make -C noise_xk $(MAKETARGET)
 
 clean:
 	rm -f *.o liboprf.$(SOEXT) liboprf.$(STATICEXT) liboprf-corrupt-dkg.$(SOEXT)
@@ -142,5 +150,11 @@ $(DESTDIR)$(PREFIX)/include/oprf/stp-dkg.h: stp-dkg.h
 test: liboprf-corrupt-dkg.$(SOEXT) liboprf.$(STATICEXT) noise_xk/liboprf-noiseXK.$(STATICEXT)
 	make -C tests tests
 	make -C noise_xk test
+
+win/libsodium-win64:
+	@echo 'win/libsodium-win64 not found.'
+	@echo 'download and unpack latest libsodium-*-mingw.tar.gz and unpack into win/'
+	@echo 'https://download.libsodium.org/libsodium/releases/'
+	@false
 
 PHONY: clean

--- a/src/noise_xk/makefile
+++ b/src/noise_xk/makefile
@@ -1,16 +1,15 @@
 PREFIX?=/usr/local
 LDFLAGS=-lsodium
 SOURCES=src/Noise_XK.c src/XK.c
-
-CFLAGS 	?= -Iinclude -I include/karmel -I include/karmel/minimal \
-				-Wall -Wextra -Werror -std=c11 -Wno-unused-variable \
+INCLUDES=-Iinclude -I include/karmel -I include/karmel/minimal
+CFLAGS 	?= -Wall -Wextra -Werror -std=c11 -Wno-unused-variable \
 				-Wno-unknown-warning-option -Wno-unused-but-set-variable \
 				-Wno-unused-parameter -Wno-infinite-recursion -fpic \
 				-g -fwrapv -D_BSD_SOURCE -D_DEFAULT_SOURCE -DWITH_SODIUM \
 				-O2 -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
 				-fasynchronous-unwind-tables -fpic \
 				-Werror=format-security -Werror=implicit-function-declaration \
-				-ftrapv
+				-ftrapv $(INCLUDES)
 CC?=gcc
 
 SOEXT?=so
@@ -37,6 +36,18 @@ else
    	CFLAGS+=-fstack-clash-protection
    endif
 endif
+
+mingw64: CC=x86_64-w64-mingw32-gcc
+mingw64: SOEXT=dll
+mingw64: STATICEXT=lib
+mingw64: EXT=.exe
+mingw64: MAKETARGET=mingw
+mingw64: CFLAGS=-march=native -Wall -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
+               -fasynchronous-unwind-tables -fpic -Werror=format-security \
+               -Werror=implicit-function-declaration -ftrapv $(DEFINES) $(INCLUDES) \
+               -I../win/libsodium-win64/include/sodium -I../win/libsodium-win64/include
+mingw64: LDFLAGS+=-L. -L.. -L../win/libsodium-win64/lib/ -Wl,-Bstatic -lsodium -Wl,-Bdynamic
+mingw64: liboprf-noiseXK.$(SOEXT)
 
 OBJS 	+= $(patsubst %.c,%.o,$(SOURCES))
 

--- a/src/noise_xk/makefile
+++ b/src/noise_xk/makefile
@@ -46,8 +46,8 @@ mingw64: CFLAGS=-march=native -Wall -O2 -g -fstack-protector-strong -D_FORTIFY_S
                -fasynchronous-unwind-tables -fpic -Werror=format-security \
                -Werror=implicit-function-declaration -ftrapv $(DEFINES) $(INCLUDES) \
                -I../win/libsodium-win64/include/sodium -I../win/libsodium-win64/include
-mingw64: LDFLAGS+=-L. -L.. -L../win/libsodium-win64/lib/ -Wl,-Bstatic -lsodium -Wl,-Bdynamic
-mingw64: liboprf-noiseXK.$(SOEXT)
+mingw64: LDFLAGS+=-L. -L.. -L../win/libsodium-win64/lib/ -Wl,-Bstatic -lsodium
+mingw64: liboprf-noiseXK.$(STATICEXT)
 
 OBJS 	+= $(patsubst %.c,%.o,$(SOURCES))
 

--- a/src/oprf.c
+++ b/src/oprf.c
@@ -19,7 +19,11 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#ifdef __WIN32__
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
 #include "oprf.h"
 #include "utils.h"
 #include "toprf.h"

--- a/src/stp-dkg.c
+++ b/src/stp-dkg.c
@@ -1,4 +1,8 @@
+#ifdef __WIN32__
+#include <winsock2.h>
+#else
 #include <arpa/inet.h> //htons
+#endif
 #include "utils.h"
 #include "stp-dkg.h"
 #include "dkg-vss.h"

--- a/src/toprf-update.c
+++ b/src/toprf-update.c
@@ -1,4 +1,8 @@
+#ifdef __WIN32__
+#include <winsock2.h>
+#else
 #include <arpa/inet.h> //htons
+#endif
 #include "utils.h"
 #include "toprf-update.h"
 #include "dkg-vss.h"

--- a/src/toprf.c
+++ b/src/toprf.c
@@ -1,7 +1,11 @@
 #include <string.h>
 #include "oprf.h"
 #include "toprf.h"
+#ifdef __WIN32__
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
 #ifdef UNIT_TEST
 #include "utils.h"
 #endif

--- a/src/tp-dkg.c
+++ b/src/tp-dkg.c
@@ -1,7 +1,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <sodium.h>
+#ifdef __WIN32__
+#include <winsock2.h>
+#else
 #include <arpa/inet.h> //htons
+#endif
 #include <sys/param.h> // __BYTE_ORDER __BIG_ENDIAN
 #include <string.h> // memcpy
 #include <stdarg.h> // va_{start|end}

--- a/src/utils.c
+++ b/src/utils.c
@@ -51,7 +51,11 @@ void fail(const char* msg, ...) {
 }
 
 #ifndef htonll
+#ifdef __WIN32__
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
 uint64_t htonll(uint64_t n) {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return n;


### PR DESCRIPTION
this PR builds a static library using mingw. a simple

```
make clean mingw64
```

should create a liboprf.a and a noise_xk/liboprf-noiseXK.a