### PR TITLE
[doc] fix spellings, add copyright to header files

### DIFF
--- a/src/dkg-vss.h
+++ b/src/dkg-vss.h
@@ -6,6 +6,9 @@
  * @brief Verifiable Secret Sharing (VSS) implementation for Distributed 
  *        Key Generation
  *
+ * SPDX-FileCopyrightText: 2025, Marsiske Stefan
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * 
  * Implements functions for Verifiable Secret Sharing, which allows participants
  * to verify that the shares they received are consistent with the commitments
  * published by the dealer, ensuring that all participants can reconstruct the

--- a/src/dkg.h
+++ b/src/dkg.h
@@ -5,6 +5,9 @@
  * @file dkg.h
  * @brief API for the Distributed Key Generation (DKG) protocol
  *
+ * SPDX-FileCopyrightText: 2025, Marsiske Stefan
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * 
  * @warning This is a low-level interface. Do not use directly unless
  * you use it to implement DKG protocols which have proper sessionids
  * and other protections against replay and confused deputy attacks.
@@ -34,7 +37,7 @@
 
     This struct communicates one detected violation of the protocol.
 
-    @var DKG_Cheater::step The step in which the violation occured
+    @var DKG_Cheater::step The step in which the violation occurred
     @var DKG_Cheater::error The error code specifying the violation
     @var DKG_Cheater::peer The peer that caused the violation
     @var DKG_Cheater::other_peer Optionally the peer that reported the
@@ -70,7 +73,7 @@ void polynom(const uint8_t j, const uint8_t threshold,
 /**
  * @brief Initiates the first step in the DKG protocol
  *
- * Ggenerates polynomial coefficients, calculates commitments, and creates
+ * Generates polynomial coefficients, calculates commitments, and creates
  * shares for all participants. Each peer should execute this function
  * at the start of the DKG protocol.
  *

--- a/src/mpmult.h
+++ b/src/mpmult.h
@@ -3,6 +3,9 @@
  * @brief API for the Distributed Key Generation (DKG) Multiplication
  *        Protocols
  *
+ * SPDX-FileCopyrightText: 2025, Marsiske Stefan
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * 
  * Implements a secure multiplication protocol that, given sharings of
  * secret `a` and secret `b`, generates a sharing of the product `a*b`
  * without revealing either secret.

--- a/src/oprf.h
+++ b/src/oprf.h
@@ -4,6 +4,9 @@
 /**
  * @file oprf.h
  * @brief API for Oblivious Pseudorandom Function (OPRF) implementation
+ * 
+ * SPDX-FileCopyrightText: 2025, Marsiske Stefan
+ * SPDX-License-Identifier: LGPL-3.0-or-later
  *
  * This file provides the API for Oblivious Pseudorandom Functions (OPRFs)
  * using the Ristretto255 group. It includes functions for key generation,
@@ -49,7 +52,7 @@ void oprf_KeyGen(uint8_t kU[crypto_core_ristretto255_SCALARBYTES]);
  * @param[in] x A value used to compute OPRF (the same value that
  *            was used as input to be blinded)
  * @param[in] x_len Length of input x in bytes.
- * @param[in] N Evaluated group element (output from oprf_Unblind)
+ * @param[in] N Evaluated group element (output from `oprf_Unblind()`)
  * @param[out] rwdU Output buffer for the OPRF result
  */
 int oprf_Finalize(const uint8_t *x, const uint16_t x_len,

--- a/src/stp-dkg.h
+++ b/src/stp-dkg.h
@@ -285,7 +285,7 @@ int stp_dkg_stpstate_step(const STP_DKG_STPState *ctx);
  *            several hours
  * @param[in] n Number of peers participating in this execution
  * @param[in] t Threshold necessary to use the results of this DKG
- * @param[in] proto_name An array of bytes used as a domain seperation tag
+ * @param[in] proto_name An array of bytes used as a domain separation tag
  *            (DST). Set it to the name of your application
  * @param[in] proto_name_len The size of the array `proto_name`, to allow
  *            non-zero terminated DSTs

--- a/src/toprf.h
+++ b/src/toprf.h
@@ -1,21 +1,3 @@
-/*
-    @copyright 2023, Stefan Marsiske toprf@ctrlc.hu
-    This file is part of liboprf.
-
-    liboprf is free software: you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public License
-    as published by the Free Software Foundation, either version 3 of
-    the License, or (at your option) any later version.
-
-    liboprf is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
-
-    You should have received a copy of the License
-    along with liboprf. If not, see <http://www.gnu.org/licenses/>.
-*/
-
 #ifndef TOPRF_H
 #define TOPRF_H
 
@@ -23,6 +5,9 @@
  * @file toprf.h
  * @brief API for the Threshold Oblivious Pseudorandom Function (TOPRF)
  *        implementation
+ * 
+ * SPDX-FileCopyrightText: 2023, Marsiske Stefan
+ * SPDX-License-Identifier: LGPL-3.0-or-later
  *
  * This file defines the structures, types, and functions for implementing
  * a Threshold Oblivious Pseudorandom Function (TOPRF) based on the
@@ -96,7 +81,7 @@ void lcoeff(const uint8_t index, const uint8_t x, const size_t degree, const uin
 void coeff(const uint8_t index, const size_t peers_len, const uint8_t peers[peers_len], uint8_t result[crypto_scalarmult_ristretto255_SCALARBYTES]);
 
 /**
- * @brief Splits a secret into `n` shares using Shamir secret sharing over
+ * @brief Splits a secret into `n` shares using Shamir's secret sharing over
  *        the curve Ristretto255
  *
  * The secret is shared in a (threshold, n) scheme: any threshold number
@@ -170,7 +155,7 @@ int toprf_Evaluate(const uint8_t k[TOPRF_Share_BYTES],
 /**
  * @brief Combines the partial results to reconstruct the final OPRF output
  *
- * This function is combines the results of the toprf_Evaluate() to recover
+ * This function is combines the results of the `toprf_Evaluate()` to recover
  * the shared secret in the exponent.
 
  * @param[in] response_len Number of elements in the `responses` array

--- a/src/tp-dkg.h
+++ b/src/tp-dkg.h
@@ -20,7 +20,7 @@
  * trusted, but does not learn the result of the DKG. If the trusted party
  * is so trusted that it can learn the result of the DKG, then it is much
  * simpler to just randomly generate a secret and then share it using
- * Shamir's Secret Sharing.
+ * Shamir's secret sharing.
  *
  * The peers only identify themselves towards the TP using long-term
  * keys, but use ephemeral keys when communicating with each other. This
@@ -319,7 +319,7 @@ int tpdkg_tpstate_step(const TP_DKG_TPState *ctx);
  *            several hours
  * @param[in] n Number of peers participating in this execution
  * @param[in] t Threshold necessary to use the results of this DKG
- * @param[in] proto_name a list of bytes used as a domain seperation tag
+ * @param[in] proto_name a list of bytes used as a domain separation tag
  *            (DST). Set it to the name of your application
  * @param[in] proto_name_len The size of the array `proto_name`, to allow
  *            non-zero terminated DSTs


### PR DESCRIPTION
Continuing from https://github.com/stef/liboprf/pull/7
- Fixed some spelling issues
- Added copyright info. I used 2025 almost everywhere, and can update if this is wrong