### PR TITLE
Further Makefile Improvements

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -62,7 +62,7 @@ OBJECTS=$(patsubst %.c,%.o,$(SOURCES))
 # Uncomment to use $ORIGIN as the runtime search path
 #SOFLAGS += -Wl,-rpath,'$$'ORIGIN
 
-all: liboprf.$(SOEXT) liboprf.$(STATICEXT) noise_xk/liboprf-noiseXK.$(SOEXT) liboprf.pc
+all: liboprf.$(SOEXT) liboprf.$(STATICEXT) noise_xk/liboprf-noiseXK.$(SOEXT) liboprf.pc liboprf_merged_localized.o
 
 debug: DEFINES=-DTRACE
 debug: all
@@ -83,10 +83,16 @@ asan: all
 AR ?= ar
 
 liboprf.$(SOEXT): $(SOURCES) noise_xk/liboprf-noiseXK.$(SOEXT)
-	$(CC) $(CFLAGS) -fPIC -shared $(SOFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -fPIC -shared $(SOFLAGS) -o $@ $(filter %.c,$^) $(LDFLAGS)
 
 liboprf-corrupt-dkg.$(SOEXT): $(SOURCES) noise_xk/liboprf-noiseXK.$(SOEXT)
-	$(CC) $(CFLAGS) -DUNITTEST -DUNITTEST_CORRUPT -fPIC -shared $(SOFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -DUNITTEST -DUNITTEST_CORRUPT -fPIC -shared $(SOFLAGS) -o $@ $(filter %.c,$^) $(LDFLAGS)
+
+liboprf_merged.o: $(OBJECTS)
+	ld -r -o $@ $^
+
+liboprf_merged_localized.o: liboprf_merged.o
+	objcopy --localize-hidden $^ $@
 
 liboprf.$(STATICEXT): $(OBJECTS)
 	$(AR) rcs $@ $^


### PR DESCRIPTION
Remove `noise_xk/liboprf-noiseXK.so` from the GCC input arguments as it is redundant.

Add a "merged" object file and a "merged localized" object file. The former exposes all "hidden" functions and should be useful for testing. The latter marks all hidden functions "local hidden" which makes it suitable for static linking with client code.

<details>

<summary>liboprf_merged.o</summary>

```
[...]
   446: 000000000001f320    10 FUNC    GLOBAL DEFAULT    2 crypto_kdf_hkdf_sha256_keybytes
   447: 0000000000007f00   879 FUNC    GLOBAL DEFAULT    2 tpdkg_cheater_msg
   448: 00000000000033b0   269 FUNC    GLOBAL HIDDEN     2 fail
   449: 0000000000003d00   490 FUNC    GLOBAL DEFAULT    2 tpdkg_tp_peer_msg
   450: 0000000000002e70   999 FUNC    GLOBAL DEFAULT    2 dkg_vss_reconstruct
   451: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND crypto_auth_verify
   452: 0000000000017420  1439 FUNC    GLOBAL DEFAULT    2 toprf_update_stp_peer_msg
   453: 0000000000003260   325 FUNC    GLOBAL HIDDEN     2 dump
   454: 000000000000af50     9 FUNC    GLOBAL DEFAULT    2 stp_dkg_peerstate_sessionid
   455: 0000000000015f40   941 FUNC    GLOBAL DEFAULT    2 toprf_update_start_stp
   456: 0000000000003820     9 FUNC    GLOBAL DEFAULT    2 tpdkg_peerstate_lt_sk
   457: 0000000000000840   249 FUNC    GLOBAL DEFAULT    2 voprf_hash_to_group
[...]
```

</details>

<details>

<summary>liboprf_merged_localized.o</summary>

```
[...]
   446: 00000000000033b0   269 FUNC    LOCAL  HIDDEN     2 fail
   447: 0000000000003260   325 FUNC    LOCAL  HIDDEN     2 dump
   448: 00000000000027c0    61 FUNC    LOCAL  HIDDEN     2 Noise_XK_session_get_key
   449: 0000000000000f60    24 FUNC    LOCAL  HIDDEN     2 coeff
   450: 0000000000000e00   352 FUNC    LOCAL  HIDDEN     2 interpolate
   451: 0000000000001ea0   142 FUNC    LOCAL  HIDDEN     2 send_msg
   452: 0000000000000008     4 OBJECT  LOCAL  HIDDEN    12 debug
   453: 00000000000016a0   292 FUNC    LOCAL  HIDDEN     2 polynom
   454: 0000000000001e20   119 FUNC    LOCAL  HIDDEN     2 check_ts
   455: 00000000000034c0    24 FUNC    LOCAL  HIDDEN     2 htonll
   456: 0000000000001f30   402 FUNC    LOCAL  HIDDEN     2 recv_msg
   457: 00000000000034e0    24 FUNC    LOCAL  HIDDEN     2 ntohll
   458: 0000000000000020    32 OBJECT  LOCAL  HIDDEN     4 H
   459: 0000000000000c70   388 FUNC    LOCAL  HIDDEN     2 lcoeff
   460: 0000000000002800   102 FUNC    LOCAL  HIDDEN     2 update_transcript
   461: 0000000000000000     8 OBJECT  LOCAL  HIDDEN    12 log_file
   462: 00000000000083d0  3171 FUNC    LOCAL  HIDDEN     2 invertedVDMmatrix
   463: 000000000001f320    10 FUNC    GLOBAL DEFAULT    2 crypto_kdf_hkdf_sha256_keybytes
   464: 0000000000007f00   879 FUNC    GLOBAL DEFAULT    2 tpdkg_cheater_msg
[...]
```

</details>