### PR TITLE
Added support for cross-compilation

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -70,6 +70,9 @@ OBJECTS=$(patsubst %.c,%.o,$(SOURCES))
 decor = $(shell [ -t 0 ] && printf "\033[38;5;2m====" || printf "====")
 endDecor = $(shell [ -t 0 ] && printf "====\033[0m" || printf "====")
 
+android: CFLAGS+=-I$(SODIUM) -I$(SODIUM)/sodium -L.
+android: liboprf.so
+
 all: liboprf.$(SOEXT) liboprf_release.$(STATICEXT) noise_xk/liboprf-noiseXK.$(SOEXT) liboprf.pc
 
 debug: DEFINES=-DTRACE

--- a/src/noise_xk/makefile
+++ b/src/noise_xk/makefile
@@ -40,6 +40,10 @@ endif
 
 OBJS 	+= $(patsubst %.c,%.o,$(SOURCES))
 
+android: CFLAGS+=-I$(SODIUM) -I$(SODIUM)/sodium
+android: LDFLAGS+=-L.
+android: liboprf-noiseXK.so
+
 all: liboprf-noiseXK.$(STATICEXT) liboprf-noiseXK.$(SOEXT)
 
 AR ?= ar


### PR DESCRIPTION
The usual suspects:

 - `-march=native` was an obvious one, and while we're at `CFLAGS`, most people won't need `-g` either (757995f16266fe093d61f3e3c6bb2ef64540a5a6)
 - `ld` was hardcoded (0f782b6)
 - using the output of `uname` is another trivial culprit (93b692b)
 - the opt-out list for `-fstack-clash-protection` lacked ARMv7 (f4ed13efeaa29aee336c232c4ed89602d0edf27f)

And as per usual, a makefile target `android` was added (193ed4432b413f63d0cd5faaf77ecf3788a4843a) to handle setting custom `libsodium` include and library paths, and focus on building just the `.so` dynamic library. This will probably be used in the near future to add JNI bindings as well.