### PR TITLE
fixed yet another hardcoded uname invocation

### DIFF
--- a/src/noise_xk/makefile
+++ b/src/noise_xk/makefile
@@ -22,7 +22,7 @@ ifeq ($(UNAME),Darwin)
    SOEXT=dylib
    SOFLAGS=-Wl,-install_name,$(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(SOEXT)
 else
-   ifeq ($(shell uname),Linux)
+   ifeq ($(UNAME),Linux)
 	CFLAGS 	+= -Wl,--error-unresolved-symbols -Wl,-z,defs -Wl,-z,relro -Wl,-z,noexecstack
 	SOEXT=so
 	SOFLAGS=-Wl,-soname,liboprf-noiseXK.$(SOEXT).$(SOVER)


### PR DESCRIPTION
Somehow I forgot to fix this, which lead to the weird combination that you could cross-compile `liboprf` on anything _but_ Linux – as it ran `uname` on the machine building it, and if it was `Linux`, it tried using GCC-specific (?) switches that `clang` (used by Android NDK) did not like:

```
x86_64-linux-android21-clang  -Wall -Wextra -Werror -std=c11 -Wno-unused-variable -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-parameter -Wno-infinite-recursion -fpic -fwrapv -D_BSD_SOURCE -D_DEFAULT_SOURCE -DWITH_SODIUM -O2 -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fasynchronous-unwind-tables -fpic -Werror=format-security -Werror=implicit-function-declaration -ftrapv -Wl,--error-unresolved-symbols -Wl,-z,defs -Wl,-z,relro -Wl,-z,noexecstack -fcf-protection=full  -fstack-clash-protection -I../../../libsodium/src/libsodium/include -I../../../libsodium/src/libsodium/include/sodium -fPIC -Iinclude -I include/karmel -I include/karmel/minimal -c src/Noise_XK.c -o src/Noise_XK.o
clang: error: -Wl,--error-unresolved-symbols: 'linker' input unused [-Werror,-Wunused-command-line-argument]
clang: error: -Wl,-z,defs: 'linker' input unused [-Werror,-Wunused-command-line-argument]
clang: error: -Wl,-z,relro: 'linker' input unused [-Werror,-Wunused-command-line-argument]
clang: error: -Wl,-z,noexecstack: 'linker' input unused [-Werror,-Wunused-command-line-argument]
make: *** [makefile:85: src/Noise_XK.o] Error 1
```