### PR TITLE
[fix] Install to location other than /usr/local.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tp-dkg
 python/tests/__pycache__/
 src/liboprf-corrupt-dkg.so
 src/liboprf.pc
+src/liboprf.so.debug

--- a/src/makefile
+++ b/src/makefile
@@ -5,10 +5,9 @@ CFLAGS?=-Wall -O2 -g -ffunction-sections -fdata-sections \
 		  -Wformat=2 -Wconversion -Wimplicit-fallthrough \
 		  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
 		  -fstack-protector-strong -fasynchronous-unwind-tables -fpic \
-		  -ftrapv -D_GLIBCXX_ASSERTIONS $(DEFINES) $(EXTRA_CFLAGS) \
-		  $(shell pkgconf --cflags libsodium)
+		  -ftrapv -D_GLIBCXX_ASSERTIONS $(DEFINES) $(EXTRA_CFLAGS) 
 
-LIBS=$(shell pkgconf --libs libsodium) -loprf-noiseXK -Lnoise_xk
+LIBS=-loprf-noiseXK -Lnoise_xk
 CC?=gcc
 LD?=ld
 OBJCOPY?=objcopy
@@ -19,7 +18,7 @@ SOVER=0
 DEBUGDIR?=lib/debug/usr/lib
 
 # To statically link the noiseXK library, use these LIBS (and comment out the other LIBS)
-#LIBS=-lsodium -l:liboprf-noiseXK.a -Wl,--exclude-libs,ALL -Lnoise_xk
+#LIBS=-l:liboprf-noiseXK.a -Wl,--exclude-libs,ALL -Lnoise_xk
 
 UNAME := $(if $(UNAME),$(UNAME),$(shell uname -s))
 ARCH := $(if $(ARCH),$(ARCH),$(shell uname -m))
@@ -53,6 +52,9 @@ SODIUM_MISSING := $(shell pkgconf --exists libsodium; echo $$?)
 ifneq ($(SODIUM_MISSING),0)
   $(error liboprf: Cannot find libsodium via pkgconf. Check that libsodium has been installed)
 endif
+
+CFLAGS+= $(shell pkgconf --cflags libsodium)
+LIBS+= $(shell pkgconf --libs libsodium)
 
 SODIUM_NEWER_THAN_1_0_18 := $(shell pkgconf --atleast-version=1.0.19 libsodium; echo $$?)
 ifneq ($(SODIUM_NEWER_THAN_1_0_18),0)

--- a/src/makefile
+++ b/src/makefile
@@ -166,13 +166,14 @@ install-oprf: $(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT) \
 install-noiseXK:
 	make -C noise_xk install
 
-uninstall: uninstall-noiseXK uninstall-oprf
+uninstall: uninstall-dircheck uninstall-noiseXK uninstall-oprf
 
-uninstall-oprf:
+uninstall-dircheck:
 	@ \
 	if [ ! '$(strip $(DESTDIR)$(PREFIX))' ]; then echo 'liboprf: DESTDIR-PREFIX is empty!' && exit 1; fi; \
 	if [ ! -d '$(strip $(DESTDIR)$(PREFIX))' ]; then echo 'liboprf: DESTDIR-PREFIX is not a folder' && exit 1; fi;
 
+uninstall-oprf:
 	rm -vf  '$(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT)' \
 	        '$(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT).$(SOVER)' \
 	        '$(DESTDIR)$(PREFIX)/lib/liboprf.$(STATICEXT)'

--- a/src/makefile
+++ b/src/makefile
@@ -164,14 +164,17 @@ install-oprf: $(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT) \
 install-noiseXK:
 	make -C noise_xk install
 
-uninstall: uninstall-oprf uninstall-noiseXK
+uninstall: uninstall-noiseXK uninstall-oprf
 
 uninstall-oprf:
 	@ \
 	if [ ! '$(strip $(DESTDIR)$(PREFIX))' ]; then echo 'liboprf: DESTDIR-PREFIX is empty!' && exit 1; fi; \
 	if [ ! -d '$(strip $(DESTDIR)$(PREFIX))' ]; then echo 'liboprf: DESTDIR-PREFIX is not a folder' && exit 1; fi;
 
-	rm -vf  '$(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT)'  '$(DESTDIR)$(PREFIX)/lib/liboprf.$(STATICEXT)'
+	rm -vf  '$(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT)' \
+	        '$(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT).$(SOVER)' \
+	        '$(DESTDIR)$(PREFIX)/lib/liboprf.$(STATICEXT)'
+
 	rm -vf  '$(DESTDIR)$(PREFIX)/include/oprf/oprf.h'  '$(DESTDIR)$(PREFIX)/include/oprf/toprf.h'
 	rm -vf  '$(DESTDIR)$(PREFIX)/include/oprf/dkg.h'  '$(DESTDIR)$(PREFIX)/include/oprf/toprf-update.h'
 	rm -vf  '$(DESTDIR)$(PREFIX)/include/oprf/utils.h' '$(DESTDIR)$(PREFIX)/lib/pkgconfig/liboprf.pc'

--- a/src/makefile
+++ b/src/makefile
@@ -5,9 +5,10 @@ CFLAGS?=-Wall -O2 -g -ffunction-sections -fdata-sections \
 		  -Wformat=2 -Wconversion -Wimplicit-fallthrough \
 		  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
 		  -fstack-protector-strong -fasynchronous-unwind-tables -fpic \
-		  -ftrapv -D_GLIBCXX_ASSERTIONS $(DEFINES) $(EXTRA_CFLAGS)
+		  -ftrapv -D_GLIBCXX_ASSERTIONS $(DEFINES) $(EXTRA_CFLAGS) \
+		  $(shell pkgconf --cflags libsodium)
 
-LIBS=-lsodium -loprf-noiseXK -Lnoise_xk
+LIBS=$(shell pkgconf --libs libsodium) -loprf-noiseXK -Lnoise_xk
 CC?=gcc
 LD?=ld
 OBJCOPY?=objcopy

--- a/src/makefile
+++ b/src/makefile
@@ -147,7 +147,7 @@ clean:
 	make -C tests clean
 	make -C noise_xk clean
 
-install: install-oprf install-noiseXK
+install: liboprf.pc install-oprf install-noiseXK
 
 install-oprf: $(DESTDIR)$(PREFIX)/lib/liboprf.$(SOEXT) \
 	$(DESTDIR)$(PREFIX)/$(DEBUGDIR)/liboprf.$(SOEXT).debug \
@@ -234,4 +234,4 @@ test: liboprf-corrupt-dkg.$(SOEXT) liboprf.$(STATICEXT) noise_xk/liboprf-noiseXK
 %.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -fPIC $(INCLUDES) -c $< -o $@
 
-PHONY: clean
+.PHONY: clean liboprf.pc

--- a/src/noise_xk/makefile
+++ b/src/noise_xk/makefile
@@ -64,8 +64,11 @@ liboprf-noiseXK.$(SOEXT).$(SOVER): liboprf-noiseXK.$(SOEXT)
 
 install: $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(SOEXT) $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(STATICEXT) $(DESTDIR)$(PREFIX)/include/oprf/noiseXK
 
-uninstall: $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(SOEXT) $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(STATICEXT) $(DESTDIR)$(PREFIX)/include/oprf/noiseXK
-	rm -rf $^
+uninstall:
+	rm -rf $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(SOEXT) \
+	       $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(SOEXT).$(SOVER) \
+	       $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(STATICEXT) \
+	       $(DESTDIR)$(PREFIX)/include/oprf/noiseXK
 
 $(DESTDIR)$(PREFIX)/lib/liboprf-noiseXK.$(SOEXT): liboprf-noiseXK.$(SOEXT)
 	mkdir -p $(DESTDIR)$(PREFIX)/lib/

--- a/src/noise_xk/makefile
+++ b/src/noise_xk/makefile
@@ -1,5 +1,5 @@
 PREFIX?=/usr/local
-LIBS=-lsodium
+LIBS=$(shell pkgconf --libs libsodium)
 SOURCES=src/Noise_XK.c src/XK.c
 INCLUDES= -Iinclude -I include/karmel -I include/karmel/minimal
 CFLAGS 	?= -Wall -Wextra -Werror -std=c11 -Wno-unused-variable \
@@ -9,7 +9,8 @@ CFLAGS 	?= -Wall -Wextra -Werror -std=c11 -Wno-unused-variable \
 				-O2 -fstack-protector-strong -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
 				-fasynchronous-unwind-tables -fpic \
 				-Werror=format-security -Werror=implicit-function-declaration \
-				-ftrapv
+				-ftrapv \
+		  		$(shell pkgconf --cflags libsodium)
 CC?=gcc
 
 SOEXT?=so


### PR DESCRIPTION
I had trouble installing liboprf to a location other than /usr/local.
Uninstall also gave some errors and had weird behavior as it copied files to the installation directory.

This PR fixes these issues.

I also added src/liboprf.so.debug to the .gitignore as this file isn't tracked by the repo.